### PR TITLE
[FIX] : storybook에서 `@emotion` `theme` 접근 에러를 수정하였습니다.

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,6 +8,7 @@ module.exports = {
     config.resolve.alias['@themes'] = path.resolve(__dirname, '../src/themes');
     config.resolve.alias['@assets'] = path.resolve(__dirname, '../src/assets');
     config.resolve.alias['@tests'] = path.resolve(__dirname, '../src/tests');
+    config.resolve.alias['@emotion/core'] = path.join(process.cwd(), 'node_modules/@emotion/react');
     return config;
   },
 };


### PR DESCRIPTION
## 개요 🔍

close #51
- `@emotion`과 `vite`를 사용할 때, `storybook`에서 정상적으로 `theme`에 접근할 수 있도록 한다.

## 작업 내용 📝

- `@emotion`에서 `theme`가 제대로 바인딩되지 않는 것으로 판단되었습니다.
- [storybook-addon-emotion-theme](https://storybook.js.org/addons/storybook-addon-emotion-theme)이라는 모듈을 확인했으나, `theme`를 사용할 수 있도록 해주는 것인데, 이미 `preview.js`에서 글로벌 테마를 추가해주었기 때문에 다시 설정하는 것은 비효율적이라 판단하여 다른 방법을 찾아보았습니다.
  - https://github.com/storybookjs/storybook/issues/10231
  - https://xo.dev/fix-storybook-emotion-11-error/
  - https://www.howdy-mj.me/storybook/setting-emotion/
- 위의 사이트에서 확인해보니, `@emotion`의 버전 `11.x.x`를 사용할 경우, 기존 `@storybook/addon-docs`에서는 `package.json`에 `@emotion`의 버전 `v10.x.x`(이 때는 `import styled from '@emotion/core`로 사용, 하였기 때문에 실제 모듈을 참조하지 않아 발생하는 오류라는 것을 확인하였습니다.
-  이에 `alias`를 설정하여 이전 버전과 링킹하였습니다.

## 기타 사항 🙋‍♂️

- `storybook`은 `webpack`을 기반으로 구성되어 있는데, 이를 `vite`로 마이그레이션할 필요가 있을 것 같습니다.
- `vite`로 마이그레이션하게 되면 `.storybook/main.js`의 `viteFinal` 메서드(현 `webpackFInal`)에서 `config`를 설정할 때, `vite.config.ts`에서 사용 중인 `alias`를 가져올 수 있을 것으로 생각됩니다. 
